### PR TITLE
Cache ollama in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -144,18 +144,18 @@ jobs:
             - name: Wait for services to be healthy
               run: |
                   echo "Waiting for services to start..."
-                  sleep 30
+                  sleep 10
 
                   # Wait for Redis to be healthy
                   timeout 30 bash -c 'until docker compose exec -T redis redis-cli ping; do sleep 2; done'
                   echo "Redis is healthy"
 
                   # Wait for Server to be healthy
-                  timeout 30 bash -c 'until curl -f http://localhost:4000/health; do sleep 5; done'
+                  timeout 30 bash -c 'until curl -f http://localhost:4000/health; do sleep 2; done'
                   echo "Server is healthy"
 
                   # Wait for Client to be healthy
-                  timeout 30 bash -c 'until curl -f http://localhost:3000/health; do sleep 5; done'
+                  timeout 30 bash -c 'until curl -f http://localhost:3000/health; do sleep 2; done'
                   echo "Client is healthy"
 
             - name: Check if services are healthy


### PR DESCRIPTION
- Updated integration test to use buildx caching feature for less spinup time
- Holds qwen model in non-ephemeral memory